### PR TITLE
Ajustes no módulo de Cooking para adequação à Clean Architecture

### DIFF
--- a/backend/src/main/java/com/snackbar/cooking/application/CookingService.java
+++ b/backend/src/main/java/com/snackbar/cooking/application/CookingService.java
@@ -6,7 +6,7 @@ import com.snackbar.cooking.entity.Cooking;
 
 public interface CookingService {
 
-    public List<Cooking> obtainAll();
+    public List<Cooking> obtainAll(List<String> statuses);
     
     public Cooking getById(String id);
 
@@ -18,7 +18,7 @@ public interface CookingService {
     
     public String finishPreparation(String id);
 
-    public List<Cooking> findByStatusOrder(String statusOrder);
+    public List<Cooking> findByStatuses(List<String> statuses);
 
     public void updateOrder(Cooking cooking);
     

--- a/backend/src/main/java/com/snackbar/cooking/application/CookingServiceImpl.java
+++ b/backend/src/main/java/com/snackbar/cooking/application/CookingServiceImpl.java
@@ -36,7 +36,7 @@ public class CookingServiceImpl implements CookingService {
         if ("PAGO".equals(cooking.getStatusOrder())) {
             cooking.setStatusOrder("RECEBIDO");
             updateOrder(cooking);
-            return "Cooking status changed to 'RECEBIDO'";
+            return "Pedido recebido";
         }
         return "The cooking is already in " + cooking.getStatusOrder() + " status";
     }
@@ -47,7 +47,7 @@ public class CookingServiceImpl implements CookingService {
         if ("RECEBIDO".equals(cooking.getStatusOrder())) {
             cooking.setStatusOrder("PREPARACAO");
             updateOrder(cooking);
-            return "Cooking status changed to 'PREPARACAO'";
+            return "Preparo iniciado";
         }
         return "The cooking is already in " + cooking.getStatusOrder() + " status";
     }
@@ -58,7 +58,7 @@ public class CookingServiceImpl implements CookingService {
         if ("PREPARACAO".equals(cooking.getStatusOrder())) {
             cooking.setStatusOrder("PRONTO");
             updateOrder(cooking);
-            return "Cooking status changed to 'PRONTO'";
+            return "Preparo pronto";
         }
         return "The cooking is currently in " + cooking.getStatusOrder() + " status";
     }

--- a/backend/src/main/java/com/snackbar/cooking/application/CookingServiceImpl.java
+++ b/backend/src/main/java/com/snackbar/cooking/application/CookingServiceImpl.java
@@ -69,12 +69,12 @@ public class CookingServiceImpl implements CookingService {
     }
 
     @Override
-    public List<Cooking> findByStatusOrder(String statusOrder) {
-        return cookingRepository.findByStatusOrder(statusOrder);
+    public List<Cooking> findByStatuses(List<String> statuses) {
+        return cookingRepository.findByStatusOrderIn(statuses);
     }
 
     @Override
-    public List<Cooking> obtainAll() {
-        return findByStatusOrder("PREPARACAO");
+    public List<Cooking> obtainAll(List<String> statuses) {
+        return findByStatuses(statuses);
     }
 }

--- a/backend/src/main/java/com/snackbar/cooking/application/CookingServiceImpl.java
+++ b/backend/src/main/java/com/snackbar/cooking/application/CookingServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.snackbar.cooking.application.usecase.*;
 import com.snackbar.cooking.entity.Cooking;
 import com.snackbar.cooking.gateway.CookingRepository;
 
@@ -12,10 +13,16 @@ import com.snackbar.cooking.gateway.CookingRepository;
 public class CookingServiceImpl implements CookingService {
 
     private final CookingRepository cookingRepository;
+    private final ReceiveOrderUseCase receiveOrderUseCase;
+    private final StartPreparationUseCase startPreparationUseCase;
+    private final FinishPreparationUseCase finishPreparationUseCase;
 
     @Autowired
     public CookingServiceImpl(CookingRepository cookingRepository) {
         this.cookingRepository = cookingRepository;
+        this.receiveOrderUseCase = new ReceiveOrderUseCase(cookingRepository);
+        this.startPreparationUseCase = new StartPreparationUseCase(cookingRepository);
+        this.finishPreparationUseCase = new FinishPreparationUseCase(cookingRepository);
     }
 
     @Override
@@ -32,35 +39,17 @@ public class CookingServiceImpl implements CookingService {
 
     @Override
     public String receiveOrder(String id) {
-        Cooking cooking = getById(id);
-        if ("PAGO".equals(cooking.getStatusOrder())) {
-            cooking.setStatusOrder("RECEBIDO");
-            updateOrder(cooking);
-            return "Pedido recebido";
-        }
-        return "The cooking is already in " + cooking.getStatusOrder() + " status";
+        return receiveOrderUseCase.execute(id);
     }
 
     @Override
     public String startPreparation(String id) {
-        Cooking cooking = getById(id);
-        if ("RECEBIDO".equals(cooking.getStatusOrder())) {
-            cooking.setStatusOrder("PREPARACAO");
-            updateOrder(cooking);
-            return "Preparo iniciado";
-        }
-        return "The cooking is already in " + cooking.getStatusOrder() + " status";
+        return startPreparationUseCase.execute(id);
     }
 
     @Override
     public String finishPreparation(String id) {
-        Cooking cooking = getById(id);
-        if ("PREPARACAO".equals(cooking.getStatusOrder())) {
-            cooking.setStatusOrder("PRONTO");
-            updateOrder(cooking);
-            return "Preparo pronto";
-        }
-        return "The cooking is currently in " + cooking.getStatusOrder() + " status";
+        return finishPreparationUseCase.execute(id);
     }
 
     @Override

--- a/backend/src/main/java/com/snackbar/cooking/application/usecase/FinishPreparationUseCase.java
+++ b/backend/src/main/java/com/snackbar/cooking/application/usecase/FinishPreparationUseCase.java
@@ -1,0 +1,25 @@
+package com.snackbar.cooking.application.usecase;
+
+import com.snackbar.cooking.entity.Cooking;
+import com.snackbar.cooking.gateway.CookingRepository;
+
+public class FinishPreparationUseCase {
+    private final CookingRepository cookingRepository;
+
+    public FinishPreparationUseCase(CookingRepository cookingRepository) {
+        this.cookingRepository = cookingRepository;
+    }
+
+    public String execute(String id) {
+        Cooking cooking = cookingRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("Cooking not found"));
+
+        if ("PREPARACAO".equals(cooking.getStatusOrder())) {
+            cooking.setStatusOrder("PRONTO");
+            cookingRepository.save(cooking);
+            return "Preparo pronto";
+        }
+
+        return "The cooking is currently in " + cooking.getStatusOrder() + " status";
+    }
+}

--- a/backend/src/main/java/com/snackbar/cooking/application/usecase/ReceiveOrderUseCase.java
+++ b/backend/src/main/java/com/snackbar/cooking/application/usecase/ReceiveOrderUseCase.java
@@ -1,0 +1,25 @@
+package com.snackbar.cooking.application.usecase;
+
+import com.snackbar.cooking.entity.Cooking;
+import com.snackbar.cooking.gateway.CookingRepository;
+
+public class ReceiveOrderUseCase {
+    private final CookingRepository cookingRepository;
+
+    public ReceiveOrderUseCase(CookingRepository cookingRepository) {
+        this.cookingRepository = cookingRepository;
+    }
+
+    public String execute(String id) {
+        Cooking cooking = cookingRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("Cooking not found"));
+
+        if ("PAGO".equals(cooking.getStatusOrder())) {
+            cooking.setStatusOrder("RECEBIDO");
+            cookingRepository.save(cooking);
+            return "Pedido recebido";
+        }
+
+        return "The cooking is already in " + cooking.getStatusOrder() + " status";
+    }
+}

--- a/backend/src/main/java/com/snackbar/cooking/application/usecase/StartPreparationUseCase.java
+++ b/backend/src/main/java/com/snackbar/cooking/application/usecase/StartPreparationUseCase.java
@@ -1,0 +1,25 @@
+package com.snackbar.cooking.application.usecase;
+
+import com.snackbar.cooking.entity.Cooking;
+import com.snackbar.cooking.gateway.CookingRepository;
+
+public class StartPreparationUseCase {
+    private final CookingRepository cookingRepository;
+
+    public StartPreparationUseCase(CookingRepository cookingRepository) {
+        this.cookingRepository = cookingRepository;
+    }
+
+    public String execute(String id) {
+        Cooking cooking = cookingRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("Cooking not found"));
+
+        if ("RECEBIDO".equals(cooking.getStatusOrder())) {
+            cooking.setStatusOrder("PREPARACAO");
+            cookingRepository.save(cooking);
+            return "Preparo iniciado";
+        }
+
+        return "The cooking is already in " + cooking.getStatusOrder() + " status";
+    }
+}

--- a/backend/src/main/java/com/snackbar/cooking/cooking.md
+++ b/backend/src/main/java/com/snackbar/cooking/cooking.md
@@ -6,9 +6,9 @@
 | <kbd>GET /api/cooking</kbd>     | See [request details](#cooking)
 | <kbd>GET /api/cooking/get-order-by-id/{id}</kbd>     |  See [request details](#get-order-by-id)
 | <kbd>GET /api/cooking/get-order-by-number/{order_number}</kbd>     |See [request details](#get-order-by-number)
-| <kbd>PUT /api/cooking/receive-order/{id}</kbd>     | See [request details](#receive-order)
-| <kbd>PUT /api/cooking/start-preparation/{id}</kbd>     | See [request details](#start-preparation)
-| <kbd>PUT /api/cooking/finish-preparation/{id}</kbd>     | See [request details](#finish-preparation)
+| <kbd>POST /api/cooking/receive-order/{id}</kbd>     | See [request details](#receive-order)
+| <kbd>POST /api/cooking/start-preparation/{id}</kbd>     | See [request details](#start-preparation)
+| <kbd>POST /api/cooking/finish-preparation/{id}</kbd>     | See [request details](#finish-preparation)
 
 
 <h3 id="cooking">GET /api/cooking</h3>
@@ -92,21 +92,21 @@
 ]
 ```
 
-<h3 id="receive-order">PUT /api/cooking/receive-order/{id}</h3>
+<h3 id="receive-order">POST /api/cooking/receive-order/{id}</h3>
 
 **RESPONSE**  
 ```json
    Pedido recebido
 ```
 
-<h3 id="start-preparation">PUT /api/cooking/start-preparation/{id}</h3>
+<h3 id="start-preparation">POST /api/cooking/start-preparation/{id}</h3>
 
 **RESPONSE**  
 ```json
    Preparo iniciado
 ```
 
-<h3 id="finish-preparation">PUT /api/cooking/finish-preparation/{id}</h3>
+<h3 id="finish-preparation">POST /api/cooking/finish-preparation/{id}</h3>
 
 **RESPONSE**  
 ```json

--- a/backend/src/main/java/com/snackbar/cooking/gateway/CookingRepository.java
+++ b/backend/src/main/java/com/snackbar/cooking/gateway/CookingRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import com.snackbar.cooking.entity.Cooking;
 
 public interface CookingRepository extends MongoRepository<Cooking, String> {
-    List<Cooking> findByStatusOrder(String statusOrder);
+    List<Cooking> findByStatusOrderIn(List<String> statuses);
     Cooking findByOrderNumber(String orderNumber);
 }

--- a/backend/src/main/java/com/snackbar/cooking/presentation/CookingController.java
+++ b/backend/src/main/java/com/snackbar/cooking/presentation/CookingController.java
@@ -44,19 +44,19 @@ public class CookingController {
         return ResponseEntity.ok(cooking);
     }
 
-    @PutMapping("/cooking/receive-order/{id}")
+    @PostMapping("/cooking/receive-order/{id}")
     public ResponseEntity<String> receiveOrder(@PathVariable String id) {
         String response = cookingService.receiveOrder(id);
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/cooking/start-preparation/{id}")
+    @PostMapping("/cooking/start-preparation/{id}")
     public ResponseEntity<String> startPreparation(@PathVariable String id) {
         String response = cookingService.startPreparation(id);
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/cooking/finish-preparation/{id}")
+    @PostMapping("/cooking/finish-preparation/{id}")
     public ResponseEntity<String> finishPreparation(@PathVariable String id) {
         String response = cookingService.finishPreparation(id);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/snackbar/cooking/presentation/CookingController.java
+++ b/backend/src/main/java/com/snackbar/cooking/presentation/CookingController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*;
 import com.snackbar.cooking.application.CookingService;
 import com.snackbar.cooking.entity.Cooking;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +21,8 @@ public class CookingController {
 
     @GetMapping("/cooking")
     public ResponseEntity<List<Cooking>> getAllCookings() {
-        List<Cooking> cookings = cookingService.findByStatusOrder("PREPARACAO");
+        List<String> statuses = Arrays.asList("PREPARACAO", "RECEBIDO", "PRONTO");
+        List<Cooking> cookings = cookingService.findByStatuses(statuses);
 
         if (cookings.isEmpty()) {
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);


### PR DESCRIPTION
# Mudanças Aplicadas

- _Services_ agora separados em _Use Cases_ separados;
- Métodos PUT alterados para POST;
- Listagem de pedidos `/cooking` agora traz os pedidos de status PREPARACAO, RECEBIDO e PRONTO.